### PR TITLE
Use dev docker image for local setup.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
   web:
     build:
       context: .
-      dockerfile: docker/Dockerfile
+      dockerfile: docker/dev.Dockerfile
     container_name: web
     links:
       - db
@@ -29,6 +29,8 @@ services:
       - .:/code
     environment:
       - SERVER_CONFIG_PATH=/code/docker/local-docker-config.json
+      - NEW_RELIC_ENABLED=false
+      - NEW_RELIC_NO_CONFIG_FILE=true
     networks:
       - voice-web
     ports:

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,27 @@
+FROM node:10-stretch
+
+# Allow exposing HTTP endpoint
+EXPOSE 9000
+
+# Add project source
+COPY . /code
+
+# Setup work directory
+WORKDIR /code
+
+# Install dependencies
+RUN apt-get update && \
+  apt-get install -y apt-transport-https && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y yarn ffmpeg
+
+# Install yarn dependencies
+RUN yarn install --dev
+
+# Run build
+RUN yarn build
+
+# Default command to start the server
+CMD yarn start


### PR DESCRIPTION
This came up as an issue while trying to run the tests in my local setup. By using the same docker image we use for production we don't install dev dependencies. This PR introduces the following:

* New minimal `dev.Dockerfile` that also installs dev dependencies for local setup.
* Setup env vars to disable New Relic for local development (breaks tests)