### PR TITLE
Fix Issue #2253: Insufficient space for left sidebar

### DIFF
--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -170,6 +170,8 @@ button {
         left: initial;
         right: initial;
         overflow: initial;
+        max-width: var(--wide-desktop-width);
+        margin: auto;
     }
 }
 

--- a/web/src/components/pages/contribution/listen/listen.css
+++ b/web/src/components/pages/contribution/listen/listen.css
@@ -4,6 +4,12 @@
     --vote-button-box-shadow: 0 5px 10px;
 }
 
+@media (max-width: 1024px){
+    .hidden-sm-down {
+        display: none;
+    }
+}
+
 .contribution.listen {
     & .instruction svg {
         max-height: 20px;

--- a/web/src/components/pages/profile/layout.css
+++ b/web/src/components/pages/profile/layout.css
@@ -76,7 +76,6 @@
                 margin: 0 auto;
                 width: 100%;
                 max-width: var(--wide-desktop-width);
-                position: absolute;
                 left: 0;
                 right: 0;
             }
@@ -92,7 +91,6 @@
             a {
                 border-radius: 40px;
                 padding: 18px 40px;
-                max-width: 200px;
 
                 display: flex;
 


### PR DESCRIPTION
### Fix Issue #2253
As mentioned in issue, it is solved by setting `max-width: var(--wide-desktop-width);` to match width with header and `margin: auto;` to align container in center.
![Screenshot from 2020-03-20 23-00-44](https://user-images.githubusercontent.com/45720335/77197484-45517500-6b0b-11ea-8009-00fb19df8754.png)

In second commit both attribute `position` and `max-width` are useless and making design worse in large screen (2560x1440)
