### PR TITLE
Adding margin left for logo container

### DIFF
--- a/web/src/components/layout/footer.css
+++ b/web/src/components/layout/footer.css
@@ -94,6 +94,7 @@ footer {
             flex-direction: column;
             min-width: 9rem;
             margin-right: 8rem;
+            margin-left: 2rem;
             margin-top: 0;
         }
 


### PR DESCRIPTION
There is no left margin to the Common Voice logo when the screen size is above 1200px.
Before Change :
![Screen Shot 2020-04-03 at 21 21 15](https://user-images.githubusercontent.com/43513114/78380345-5614e700-75f1-11ea-8315-2706cbd60abd.png)

After Change: 
![Screen Shot 2020-04-03 at 21 23 51](https://user-images.githubusercontent.com/43513114/78380519-9e340980-75f1-11ea-93af-c1b6475aef43.png)

