### PR TITLE
Add logging for voice avatar and base64 upload handlers

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -305,7 +305,7 @@ export default class API {
   // TODO: Check for empty or silent clips before uploading.
   saveAvatarClip = async (request: Request, response: Response) => {
     const { client_id, headers, user } = request;
-
+    console.log(`VOICE_AVATAR: saveAvatarClip() called, ${client_id}`);
     const folder = client_id;
     const clipFileName = folder + '.mp3';
     try {
@@ -314,6 +314,9 @@ export default class API {
       if ((headers['content-type'] as string).includes('base64')) {
         // If we were given base64, we'll need to concat it all first
         // So we can decode it in the next step.
+        console.log(
+          `VOICE_AVATAR: base64 to saveAvatarClip(), ${clipFileName}`
+        );
         const chunks: Buffer[] = [];
         await new Promise(resolve => {
           request.on('data', (chunk: Buffer) => {
@@ -413,7 +416,11 @@ export default class API {
     { client_id, params, body }: Request,
     response: Response
   ) => {
-    await this.model.db.insertDownloader(params.locale, body.email, body.dataset);
+    await this.model.db.insertDownloader(
+      params.locale,
+      body.email,
+      body.dataset
+    );
     response.json({});
   };
 

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -156,8 +156,8 @@ export default class Clip {
     const filePrefix = sentenceId;
     const clipFileName = folder + filePrefix + '.mp3';
 
-    // if the folder does not exist, we create it
     try {
+      // If the folder does not exist, we create it.
       await this.s3
         .putObject({ Bucket: getConfig().BUCKET_NAME, Key: folder })
         .promise();
@@ -167,6 +167,7 @@ export default class Clip {
       if ((headers['content-type'] as string).includes('base64')) {
         // If we were given base64, we'll need to concat it all first
         // So we can decode it in the next step.
+        console.log(`VOICE_AVATAR: base64 to saveClip(), ${clipFileName}`);
         const chunks: Buffer[] = [];
         await new Promise(resolve => {
           request.on('data', (chunk: Buffer) => {


### PR DESCRIPTION
We have a lot of dead code in our codebase built around the
eventual desire to ship the voice avatar.

I am investigating bugs around clip recording and uploading, so I want
to ensure these paths are never hit in our codebase. By adding some
simple logs, I can check back in Papertrail after a week or so to ensure
these conditions weren't triggered. If they weren't, good. If they were,
hello bug!