### PR TITLE
Clear some cobwebs from our page layout

### DIFF
--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -78,7 +78,6 @@ interface LocalizedPagesProps
 }
 
 interface LocalizedPagesState {
-  hasScrolled: boolean;
   l10n: ReactLocalization | null;
   uploadPercentage?: number;
 }
@@ -89,7 +88,6 @@ let LocalizedPage: any = class extends React.Component<
 > {
   seenAwardIds: number[] = [];
   state: LocalizedPagesState = {
-    hasScrolled: false,
     l10n: null,
     uploadPercentage: null,
   };
@@ -98,8 +96,6 @@ let LocalizedPage: any = class extends React.Component<
 
   async componentDidMount() {
     await this.prepareBundleGenerator(this.props);
-    window.addEventListener('scroll', this.handleScroll);
-    setTimeout(() => this.setState({ hasScrolled: true }), 5000);
     this.props.refreshUser();
   }
 
@@ -142,10 +138,6 @@ let LocalizedPage: any = class extends React.Component<
       );
       await api.seenAwards('notification');
     }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('scroll', this.handleScroll);
   }
 
   async runUploads(uploads: Uploads.State) {
@@ -208,12 +200,6 @@ let LocalizedPage: any = class extends React.Component<
       ),
     });
   }
-
-  handleScroll = () => {
-    if (!this.state.hasScrolled) {
-      this.setState({ hasScrolled: true });
-    }
-  };
 
   render() {
     const { locale, notifications, toLocaleRoute } = this.props;

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -154,6 +154,8 @@ button {
 }
 
 #scroller {
+    -webkit-overflow-scrolling: touch;
+    scroll-behavior: smooth;
     position: fixed;
     top: var(--header-height);
     bottom: 0;
@@ -163,6 +165,11 @@ button {
     overflow-y: scroll;
     z-index: 0;
 
+    @media (--md-up) {
+        -webkit-overflow-scrolling: initial;
+        scroll-behavior: initial;
+    }
+
     @media (--lg-up) {
         position: relative;
         top: initial;
@@ -170,16 +177,6 @@ button {
         left: initial;
         right: initial;
         overflow: initial;
-    }
-}
-
-body:not(.focus) #scroller {
-    -webkit-overflow-scrolling: touch;
-    scroll-behavior: smooth;
-
-    @media (--md-up) {
-        -webkit-overflow-scrolling: initial;
-        scroll-behavior: initial;
     }
 }
 

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -67,7 +67,6 @@ interface LayoutState {
   challengeToken: ChallengeToken;
   isMenuVisible: boolean;
   hasScrolled: boolean;
-  hasScrolledDown: boolean;
   showStagingBanner: boolean;
   showWelcomeModal: boolean;
   featureStorageKey?: string;
@@ -147,7 +146,6 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     challengeToken: undefined,
     isMenuVisible: false,
     hasScrolled: false,
-    hasScrolledDown: false,
     showStagingBanner: !isProduction(),
     showWelcomeModal: false,
     featureStorageKey: null,
@@ -211,14 +209,11 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     }
   }
 
-  lastScrollTop: number;
   private handleScroll = () => {
     const { scrollTop } = this.scroller;
     this.setState({
       hasScrolled: scrollTop > 0,
-      hasScrolledDown: scrollTop > this.lastScrollTop,
     });
-    this.lastScrollTop = scrollTop;
   };
 
   private toggleMenu = () => {
@@ -266,7 +261,6 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
       challengeTeamToken,
       challengeToken,
       hasScrolled,
-      hasScrolledDown,
       isMenuVisible,
       showStagingBanner,
       showWelcomeModal,
@@ -307,10 +301,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
         {showStagingBanner && (
           <div className="staging-banner">
             You're on the staging server. Voice data is not collected here.{' '}
-            <a
-              href={URLS.HTTP_ROOT}
-              target="_blank"
-              rel="noopener noreferrer">
+            <a href={URLS.HTTP_ROOT} target="_blank" rel="noopener noreferrer">
               Don't waste your breath.
             </a>{' '}
             <a
@@ -325,12 +316,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
           </div>
         )}
         <header
-          className={
-            !isMenuVisible &&
-            (hasScrolled ? 'active' : '') +
-              ' ' +
-              (hasScrolledDown ? 'hidden' : '')
-          }
+          className={!isMenuVisible && (hasScrolled ? 'active' : '')}
           ref={header => {
             this.header = header as HTMLElement;
           }}>

--- a/web/src/components/pages/faq/faq.css
+++ b/web/src/components/pages/faq/faq.css
@@ -56,7 +56,11 @@
         & .header-line {
             width: 70px;
             height: 3px;
-            background: linear-gradient(to right, var(--gradient-pink), var(--gradient-purple));
+            background: linear-gradient(
+                to right,
+                var(--gradient-pink),
+                var(--gradient-purple)
+            );
 
             @media (--md-down) {
                 margin-bottom: 20px;
@@ -308,7 +312,11 @@
 
             & .line {
                 height: 3px;
-                background: linear-gradient(to right, var(--gradient-pink), var(--gradient-purple));
+                background: linear-gradient(
+                    to right,
+                    var(--gradient-pink),
+                    var(--gradient-purple)
+                );
                 margin: 0 75px 30px;
 
                 @media (--md-down) {
@@ -550,9 +558,5 @@
                 }
             }
         }
-    }
-
-    .hidden {
-        display: none;
     }
 }


### PR DESCRIPTION
Prompted by a surprising layout breakage on our new error pages, I found some oddities in our page layout. This is my attempt to simplify a few years of uh, iterative development.

I did a bunch of detective work and testing while going through this, which I've tried to document below. But please let me know if you have any questions or concerns!

I've got a big change to follow this one to get rid of the `#scroller` and `#scrollee` containers, but that deserves its own commit and explanation. This is some comparatively simple prep work.

Here are the changes, explained:

---

- Remove an unused `.focus` style.

Added in 2017 (pre 60ae00771519), this class was used to add custom Firefox Focus scroll behaviour. The class was removed in 16d38229594d, but I accidentally left a custom rule in place (unused since 16d38229594d).

- Remove some unused / duplicate `hasScrolled` state from `app.tsx`.

Honestly I didn't dive deep into this one because it's obviously not being used. The same `hasScrolled` behaviour is duplicated in `layout.tsx` so I assume it was just moved-but-not-deleted somewhere along the way.

- Remove an unused `.hidden` class (and associated `hasScrolledDown` logic).

It looks like there were plans to make the header hide itself on scroll, but that never happened. This was added in 225b84b75136 and never used. Better solutions exist in 2020, so rather than keep this around we should get rid of it.

- Remove an unused `.hidden` style.

Confusing! There _was_ a `.hidden` class (see above), but not within `.faq-hero`. This was added in 06b8c3ceb471 and apparently never used.

---

And that's it. Just in time for some real QA before release! Which is great, because this is gonna need it :)