### PR TITLE
Remove the "scroller" and "scrollee" scroll containers

### DIFF
--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -208,7 +208,7 @@ let LocalizedPage: any = class extends React.Component<
     if (!l10n) return null;
 
     return (
-      <div>
+      <>
         <div
           className="upload-progress"
           style={
@@ -266,7 +266,7 @@ let LocalizedPage: any = class extends React.Component<
             </Switch>
           </div>
         </LocalizationProvider>
-      </div>
+      </>
     );
   }
 };

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -22,14 +22,7 @@ html {
     font-size: var(--font-size);
     color: var(--black);
     background-color: var(--white);
-    overflow: auto;
     scroll-behavior: smooth;
-}
-
-@media (--md-down) {
-    html {
-        overflow: hidden;
-    }
 }
 
 html,
@@ -151,37 +144,6 @@ button {
     box-sizing: border-box;
     background-color: var(--white);
     animation: fadein var(--transition-duration-slow) linear;
-}
-
-#scroller {
-    -webkit-overflow-scrolling: touch;
-    scroll-behavior: smooth;
-    position: fixed;
-    top: var(--header-height);
-    bottom: 0;
-    left: 0;
-    right: 0;
-    overflow-x: hidden;
-    overflow-y: scroll;
-    z-index: 0;
-
-    @media (--md-up) {
-        -webkit-overflow-scrolling: initial;
-        scroll-behavior: initial;
-    }
-
-    @media (--lg-up) {
-        position: relative;
-        top: initial;
-        bottom: initial;
-        left: initial;
-        right: initial;
-        overflow: initial;
-    }
-}
-
-#scrollee {
-    position: relative;
 }
 
 .profile #content {

--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -16,10 +16,7 @@ const LocalizedLocaleLink = ({ id, to }: { id: string; to: string }) => {
   const [locale] = useLocale();
   return (
     <Localized id={id}>
-      <LocaleLink
-        to={to}
-        onClick={() => trackNav(id, locale)}
-      />
+      <LocaleLink to={to} onClick={() => trackNav(id, locale)} />
     </Localized>
   );
 };
@@ -29,10 +26,7 @@ export default React.memo(() => {
   return (
     <footer>
       <div id="help-links">
-        <LocaleLink
-          to={URLS.FAQ}
-          onClick={() => trackNav('faq', locale)}
-        >
+        <LocaleLink to={URLS.FAQ} onClick={() => trackNav('faq', locale)}>
           <SupportIcon />
           <Localized id="faq">
             <div />
@@ -58,11 +52,13 @@ export default React.memo(() => {
             <Localized
               id="content-license-text"
               elems={{
-                licenseLink: <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://www.mozilla.org/en-US/foundation/licensing/website-content/"
-                />
+                licenseLink: (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://www.mozilla.org/en-US/foundation/licensing/website-content/"
+                  />
+                ),
               }}>
               <span />
             </Localized>
@@ -104,7 +100,7 @@ export default React.memo(() => {
           <TextButton
             className="back-top"
             onClick={() => {
-              document.getElementById('scroller').scrollTop = 0;
+              window.scrollTo({ top: 0, behavior: 'smooth' });
             }}
           />
         </Localized>

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -137,8 +137,6 @@ const SegmentBanner = ({
 };
 
 class Layout extends React.PureComponent<LayoutProps, LayoutState> {
-  private header: HTMLElement;
-  private scroller: HTMLElement;
   private installApp: HTMLElement;
 
   state: LayoutState = {
@@ -153,7 +151,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
   async componentDidMount() {
     const { locale, api, user } = this.props;
-    this.scroller.addEventListener('scroll', this.handleScroll);
+    window.addEventListener('scroll', this.handleScroll);
     this.visitHash();
 
     const challengeTeamToken = this.getTeamToken();
@@ -180,10 +178,6 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
       // Immediately scrolling up after page change has no effect.
       setTimeout(() => {
-        if (this.scroller) {
-          this.scroller.scrollTop = 0;
-        }
-
         if (location.hash) {
           this.visitHash();
         } else {
@@ -197,7 +191,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   }
 
   componentWillUnmount() {
-    this.scroller.removeEventListener('scroll', this.handleScroll);
+    window.removeEventListener('scroll', this.handleScroll);
   }
 
   private visitHash() {
@@ -210,9 +204,9 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   }
 
   private handleScroll = () => {
-    const { scrollTop } = this.scroller;
+    const { scrollY } = window;
     this.setState({
-      hasScrolled: scrollTop > 0,
+      hasScrolled: scrollY > 0,
     });
   };
 
@@ -298,28 +292,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
               featureStorageKey={featureStorageKey}
             />
           )}
-        {showStagingBanner && (
-          <div className="staging-banner">
-            You're on the staging server. Voice data is not collected here.{' '}
-            <a href={URLS.HTTP_ROOT} target="_blank" rel="noopener noreferrer">
-              Don't waste your breath.
-            </a>{' '}
-            <a
-              href={`${URLS.GITHUB_ROOT}/issues/new`}
-              rel="noopener noreferrer"
-              target="_blank">
-              Feel free to report issues.
-            </a>{' '}
-            <button onClick={() => this.setState({ showStagingBanner: false })}>
-              Close
-            </button>
-          </div>
-        )}
-        <header
-          className={!isMenuVisible && (hasScrolled ? 'active' : '')}
-          ref={header => {
-            this.header = header as HTMLElement;
-          }}>
+        <header className={hasScrolled ? 'active' : ''}>
           <div>
             <Logo />
             <Nav id="main-nav" />
@@ -352,16 +325,25 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
             </button>
           </div>
         </header>
-        <div
-          id="scroller"
-          ref={div => {
-            this.scroller = div as HTMLElement;
-          }}>
-          <div id="scrollee">
-            <Content location={location} />
-            <Footer />
+        {showStagingBanner && (
+          <div className="staging-banner">
+            You're on the staging server. Voice data is not collected here.{' '}
+            <a href={URLS.HTTP_ROOT} target="_blank" rel="noopener noreferrer">
+              Don't waste your breath.
+            </a>{' '}
+            <a
+              href={`${URLS.GITHUB_ROOT}/issues/new`}
+              rel="noopener noreferrer"
+              target="_blank">
+              Feel free to report issues.
+            </a>{' '}
+            <button onClick={() => this.setState({ showStagingBanner: false })}>
+              Close
+            </button>
           </div>
-        </div>
+        )}
+        <Content location={location} />
+        <Footer />
         <div
           id="navigation-modal"
           className={this.state.isMenuVisible ? 'active' : ''}>

--- a/web/src/components/layout/nav.css
+++ b/web/src/components/layout/nav.css
@@ -1,10 +1,8 @@
 @import url('../vars.css');
 
 header {
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
     display: flex;
     align-items: center;
     height: var(--header-height);
@@ -29,11 +27,9 @@ header {
 
     &.active {
         box-shadow: var(--nav-shadow-overhang);
-        background-color: var(--white);
 
         @media (--lg-up) {
             box-shadow: none;
-            background-color: initial;
         }
     }
 

--- a/web/src/components/pages/error-page/error-page.css
+++ b/web/src/components/pages/error-page/error-page.css
@@ -15,16 +15,12 @@
         }
     }
 
-    #scroller,
-    #scrollee,
     #content,
     .mars {
         display: flex;
         flex-direction: column;
     }
 
-    #scroller,
-    #scrollee,
     #content,
     .error-page-container-outer {
         flex-grow: 1;


### PR DESCRIPTION
# Depends on https://github.com/mozilla/common-voice/pull/2863

Remove the "scroller" and "scrollee" scroll containers

A more ambitious follow-up to my [my previous layout PR](https://github.com/mozilla/common-voice/pull/2863).

> Prompted by a surprising layout breakage on our new error pages, I found some oddities in our page layout. This is my attempt to simplify a few years of uh, iterative development.

Prior to this change, each of our pages lived within a nested `div#scroller` and `div#scrollee` container. On desktop these were inconspicuous wrapper `div`s. But on mobile, `#scroller` took on a `position: fixed` over the viewport, and `#scrollee` scrolled within it. With banners, dynamically-sized elements, and new flexbox layouts, keeping everything in a fixed panel has started to cause surprising bugs:

![An error page, ironically displaying a horrible layout bug](https://i.imgur.com/dDpAvW4.png)

The solution is one part new, one part old. I've combined the simple scroll check introduced in 1c58f6df2a5c with `position: sticky` for a _waaaay_ less verbose and mobile-platform-breaking experience!

It also fixes a bunch of weird overflow bugs that were too annoying to fix individually but really piled up. For instance: banners no-longer block their underlying content!

Before:

![Banner is overlapping the underlying content](https://i.imgur.com/e9FDCT2.png)

After: 

![Banner is NOT overlapping the underlying content](https://i.imgur.com/pyPrNpQ.png)

---

*This change should go through some heavy QA!* Things to look out for:

- Pages that now have content overflowing horizontally, including the header bar, backgrounds, and "floating" images.
- Pages with wonky scroll behaviour, especially at the top or bottom of pages.
- Banners or other fixed-position elements that now seem to be in the wrong position.
- Pages that cannot scroll at all…? Hope not!
