### PR TITLE
Prevent blank clips sent to the server from propagating

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "@types/react-router": "^5.1.2",
     "@types/react-router-dom": "^5.1.0",
     "amplitude-js": "^5.10.0",
-    "audio-recorder-polyfill": "^0.3.6",
+    "audio-recorder-polyfill": "^0.3.8",
     "classnames": "^2.2.6",
     "downshift": "^3.2.10",
     "fluent": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-audio-recorder-polyfill@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/audio-recorder-polyfill/-/audio-recorder-polyfill-0.3.6.tgz#8d866541efe41d65d56e1093ee0240f571f427be"
-  integrity sha512-yPFXIQMKfIsHTCiNt8Vm4e0UQbnJxeOaVUStEEkV1satYcxaG02ZNite8lpVMCAXJoNnxF2GHVGfIgukPXvtAw==
+audio-recorder-polyfill@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/audio-recorder-polyfill/-/audio-recorder-polyfill-0.3.8.tgz#ce2352e9e72f820f4e2aca94ae604caa1dafa09d"
+  integrity sha512-vPBQIIf9AZtvjDbcD216KONL98nIqSffHJ4k11JoxKUuuDTQ+jGuX21Q+5ri7dSMb+qNeilOaPyhlAhCJlaexQ==
 
 autoprefixer@^9.6.1:
   version "9.7.4"


### PR DESCRIPTION
Hopefully over time we send less and less blank clips from the client.
But until every client and device is perfectly reliable, we should also
double-check that clips are valid on the server. For now, we're using
file size as a proxy for that.

After this commit, this is the flow of an audio clip from the client, to
the server, to AWS, to the DB:

- Clip is recorded on the client
- Clip is submitted to the server
- HTTP stream of the clip is streamed to ffmpeg, which is then piped to
  an AWS streaming upload
- Once the upload and transcoding are complete, if the audio clip is
  invalid or resulted in an mp3 size < 300 bytes, we bail and delete the
  file from AWS
- Otherwise, we consider it valid and save it to the DB

Specific changes in this commit:

- Update audio-recording-polyfill to hopefully reduce incidence of blank
  clips from the client
- Add ^that whole error-checking flow^ on the server
- Add a few transcoding options to ffmpeg to ensure consistent #
  channels and sample rate.