### PR TITLE
Disable the restriction of single sentence limit for all locales

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -206,7 +206,8 @@ export default class DB {
   ): Promise<Sentence[]> {
     let taxonomySentences: Sentence[] = [];
     const locale_id = await getLocaleId(locale);
-    const exemptFromSSRL = SMALL_LANGUAGE_COMMUNITIES.includes(locale);
+    // const exemptFromSSRL = SMALL_LANGUAGE_COMMUNITIES.includes(locale);
+    const exemptFromSSRL = true;
 
     if (this.inBenchmark(locale)) {
       taxonomySentences = await this.findSentencesMatchingTaxonomy(
@@ -318,7 +319,8 @@ export default class DB {
   ): Promise<DBClipWithVoters[]> {
     let taxonomySentences: DBClipWithVoters[] = [];
     const locale_id = await getLocaleId(locale);
-    const exemptFromSSRL = SMALL_LANGUAGE_COMMUNITIES.includes(locale);
+    // const exemptFromSSRL = SMALL_LANGUAGE_COMMUNITIES.includes(locale);
+    const exemptFromSSRL = true;
 
     if (this.inBenchmark(locale)) {
       taxonomySentences = await this.findClipsMatchingTaxonomy(


### PR DESCRIPTION
Temp. revert feature from #2757 that restricts all sentences to be recorded only for once. 
Ease the contributing for all locales without new sentences add fast enough. 
resolve https://github.com/mozilla/common-voice/issues/2948