### PR TITLE
Fix clip id type

### DIFF
--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -70,7 +70,7 @@ export default class Bucket {
           console.log(
             `clip_id ${id} by ${client_id} for sentence ${original_sentence_id} is smaller than 256 bytes`
           );
-          await this.model.db.deleteClip(id);
+          await this.model.db.deleteClip(id.toString());
           await this.s3.deleteObject(
             {
               Bucket: getConfig().CLIP_BUCKET_NAME,


### PR DESCRIPTION
Fixes:
```
[1] FAIL src/test/upload-recording.test.ts
[1]   ● Test suite failed to run
[1]     TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
[1]     src/lib/bucket.ts:69:42 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
[1]     69           await this.model.db.deleteClip(id);
[1]     src/lib/bucket.ts:72:35 - error TS2339: Property 'CLIP_BUCKET_NAME' does not exist on type 'CommonVoiceConfig'.
[1]     72               Bucket: getConfig().CLIP_BUCKET_NAME,
```